### PR TITLE
Add tslint and typescript to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "tslint-plugin"
   ],
   "license": "MIT",
-  "dependencies": {
-    "tslint": "~5.8.0"
+  "peerDependencies": {
+    "tslint": "~5.8.0",
+    "typescript": "~2.5.3",
   },
   "devDependencies": {
-    "typescript": "~2.5.3",
     "chokidar-cli": "~1.2.0"
   },
   "watch": {


### PR DESCRIPTION
Seems that `tslint` and `typescript` should be `peerDependencies` as soon the package is "plugin" for tslint.

See other tslint rule plugins:
https://github.com/Microsoft/tslint-microsoft-contrib/blob/master/package.json#L57-L60
https://github.com/buzinas/tslint-eslint-rules/blob/master/package.json#L41-L44